### PR TITLE
add btcBlockHeight to withdraw flow

### DIFF
--- a/src/SovaL1Block.sol
+++ b/src/SovaL1Block.sol
@@ -14,9 +14,9 @@ import "./interfaces/ISovaL1Block.sol";
  * @custom:predeploy 0x2100000000000000000000000000000000000015
  */
 contract SovaL1Block is ISovaL1Block {
-    uint64 public currentBlockHeight;
-    bytes32 public blockHashSixBlocksBack;
-    uint256 public lastUpdatedBlock;
+    uint64 private currentBlockHeight;
+    bytes32 private blockHashSixBlocksBack;
+    uint256 private lastUpdatedBlock;
 
     function version() public pure virtual returns (string memory) {
         return "0.1.0-beta.1";
@@ -53,9 +53,5 @@ contract SovaL1Block is ISovaL1Block {
             sstore(blockHashSixBlocksBack.slot, calldataload(36)) // bytes32
             sstore(lastUpdatedBlock.slot, number()) // block.number
         }
-    }
-
-    function getL1BlockInfo() external view returns (bytes32, uint256, uint256) {
-        return (blockHashSixBlocksBack, currentBlockHeight, lastUpdatedBlock);
     }
 }

--- a/src/UBTC.sol
+++ b/src/UBTC.sol
@@ -153,9 +153,14 @@ contract UBTC is WETH, IUBTC, Ownable, ReentrancyGuard {
      *
      * @param amount            The amount of satoshis to withdraw
      * @param btcGasLimit       Specified gas limit for the Bitcoin transaction (in satoshis)
+     * @param btcBlockHeight    The current BTC block height. This is used to source spendable Bitcoin UTXOs
      * @param dest              The destination Bitcoin address (bech32)
      */
-    function withdraw(uint64 amount, uint64 btcGasLimit, string calldata dest) external nonReentrant whenNotPaused {
+    function withdraw(uint64 amount, uint64 btcGasLimit, uint32 btcBlockHeight, string calldata dest)
+        external
+        nonReentrant
+        whenNotPaused
+    {
         // Input validation
         if (amount == 0) {
             revert ZeroAmount();
@@ -178,11 +183,8 @@ contract UBTC is WETH, IUBTC, Ownable, ReentrancyGuard {
 
         _burn(msg.sender, totalRequired);
 
-        // read current block height from state
-        uint64 blockHeight = ISovaL1Block(SovaBitcoin.SOVA_L1_BLOCK_ADDRESS).currentBlockHeight();
-
         bytes memory inputData =
-            abi.encode(SovaBitcoin.UBTC_SIGN_TX_BYTES, msg.sender, amount, btcGasLimit, blockHeight, dest);
+            abi.encode(SovaBitcoin.UBTC_SIGN_TX_BYTES, msg.sender, amount, btcGasLimit, btcBlockHeight, dest);
 
         // This call will set the slot locks for this contract until the slot resolution is done. Then the
         // slot updates will either take place or be reverted.

--- a/src/interfaces/ISovaL1Block.sol
+++ b/src/interfaces/ISovaL1Block.sol
@@ -2,15 +2,6 @@
 pragma solidity 0.8.15;
 
 interface ISovaL1Block {
-    /// @notice The latest Bitcoin block number known by the Sova system.
-    function currentBlockHeight() external view returns (uint64);
-
-    /// @notice The Bitcoin block hash from 6 blocks back from current block height.
-    function blockHashSixBlocksBack() external view returns (bytes32);
-
-    /// @notice Store the last sova block the values were updated.
-    function lastUpdatedBlock() external view returns (uint256);
-
     /// @notice Returns the contract version.
     function version() external pure returns (string memory);
 
@@ -28,7 +19,4 @@ interface ISovaL1Block {
     ///   1. _blockHeight         Current Bitcoin block height
     ///   2. _blockHash           Bitcoin blockhash from 6 blocks back
     function setBitcoinBlockDataCompact() external;
-
-    /// @notice Get current Bitcoin block data
-    function getL1BlockInfo() external view returns (bytes32, uint256, uint256);
 }

--- a/src/interfaces/IUBTC.sol
+++ b/src/interfaces/IUBTC.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.15;
 interface IUBTC {
     /// @notice Bitcoin-specific functions
     function depositBTC(uint64 amount, bytes calldata signedTx) external;
-    function withdraw(uint64 amount, uint64 btcGasLimit, string calldata dest) external;
+    function withdraw(uint64 amount, uint64 btcGasLimit, uint32 btcBlockHeight, string calldata dest) external;
 
     /// @notice Administrative functions
     function adminBurn(address wallet, uint256 amount) external;


### PR DESCRIPTION
Due to the way the slot reverts are applied in 'simulation mode' we cannot read from the SovaL1Block state during simulation because the inspector will read an outdated value and the precompiles will have different execution results in simulation vs actual execution in the payload builder an execution flows.