### PR TITLE
milo-info-1

### DIFF
--- a/src/SovaL1Block.sol
+++ b/src/SovaL1Block.sol
@@ -29,7 +29,7 @@ contract SovaL1Block is ISovaL1Block {
     }
 
     function setBitcoinBlockData(uint64 _blockHeight, bytes32 _blockHash) external {
-        require(msg.sender == SYSTEM_ACCOUNT_ADDRESS, "BitcoinBlock: only the system account can set block data");
+        require(msg.sender == SYSTEM_ACCOUNT_ADDRESS, "SovaL1Block: only the system account can set block data");
 
         currentBlockHeight = _blockHeight;
         blockHashSixBlocksBack = _blockHash;

--- a/src/interfaces/ISovaL1Block.sol
+++ b/src/interfaces/ISovaL1Block.sol
@@ -5,18 +5,8 @@ interface ISovaL1Block {
     /// @notice Returns the contract version.
     function version() external pure returns (string memory);
 
-    /// @notice Address of the special depositor account.
-    function SYSTEM_ACCOUNT() external pure returns (address);
-
     /// @notice Updates the Bitcoin block values.
     /// @param _blockHeight      Current Bitcoin block height.
     /// @param _blockHash        Bitcoin blockhash from 6 blocks back.
     function setBitcoinBlockData(uint64 _blockHeight, bytes32 _blockHash) external;
-
-    /// @notice Updates the Bitcoin block values with compact calldata for gas efficiency.
-    /// Params are packed and passed in as raw msg.data instead of ABI to reduce calldata size.
-    /// Params are expected to be in the following order:
-    ///   1. _blockHeight         Current Bitcoin block height
-    ///   2. _blockHash           Bitcoin blockhash from 6 blocks back
-    function setBitcoinBlockDataCompact() external;
 }


### PR DESCRIPTION
Typo: "hieght" -> "height".

`version()` function  declared external.

 SYSTEM_ACCOUNT should be a constant.

Both the setBitcoinBlockData() and setBitcoinBlockDataCompact() functions implement the same logic of setting state variables in the contract; there isn't a need for both functions. Removed setBitcoinBlockDataCompact().