### PR TITLE
milo-low-7

### DIFF
--- a/src/lib/SovaBitcoin.sol
+++ b/src/lib/SovaBitcoin.sol
@@ -16,11 +16,6 @@ library SovaBitcoin {
     /// @notice Native Bitcoin wrapper address
     address public constant UBTC_ADDRESS = 0x2100000000000000000000000000000000000020;
 
-    /// @notice Bitcoin locktime threshold
-    /// @dev Below this value locktime is interpreted as block number, otherwise as timestamp.
-    /// @dev https://github.com/bitcoin/bitcoin/blob/084eee029199a741c58e5537b332bd8360a1bdc3/src/script/script.h#L47
-    uint256 public constant LOCKTIME_THRESHOLD = 500000000;
-
     /// @notice Bitcoin precompile selectors
     bytes4 public constant BROADCAST_BYTES = 0x00000001;
     bytes4 public constant DECODE_BYTES = 0x00000002;
@@ -137,21 +132,8 @@ library SovaBitcoin {
             revert InsufficientInput();
         }
 
-        if (btcTx.locktime > block.timestamp) {
-            revert InvalidLocktime();
-        }
-
-        // Locktime validation, only allow timestamp-based locktimes or zero
         if (btcTx.locktime != 0) {
-            if (btcTx.locktime < LOCKTIME_THRESHOLD) {
-                // Reject all block-number based locktimes
-                revert InvalidLocktime();
-            }
-
-            // Validate timestamp-based locktime
-            if (btcTx.locktime > block.timestamp) {
-                revert InvalidLocktime();
-            }
+            revert InvalidLocktime();
         }
 
         // Recover the callers unique bitcoin deposit address


### PR DESCRIPTION
restrict deposit txs to have a locktime of 0. There is a conditional applied in the locktime processing lock in bitcoin core which differentiates inputs above and below 500000000 differently.

https://github.com/bitcoin/bitcoin/blob/084eee029199a741c58e5537b332bd8360a1bdc3/src/script/script.h#L47