### PR TITLE
Add TokenWrapper tests and ERC20 mock

### DIFF
--- a/test/TokenWrapper.t.sol
+++ b/test/TokenWrapper.t.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import "forge-std/Test.sol";
+import "../src/SovaBTC.sol";
+import "../src/TokenWrapper.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "./mocks/MockERC20BTC.sol";
+
+contract TokenWrapperTest is Test {
+    SovaBTC internal sovaBTC;
+    TokenWrapper internal wrapper;
+    MockERC20BTC internal wbtc;
+    MockERC20BTC internal lbtc;
+    address internal admin;
+    address internal user1;
+    address internal user2;
+
+    function setUp() public {
+        admin = address(0xA11CE);
+        user1 = address(0xB0B);
+        user2 = address(0xC0C);
+
+        // Deploy core contracts
+        sovaBTC = new SovaBTC();
+        TokenWrapper impl = new TokenWrapper();
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), "");
+        wrapper = TokenWrapper(address(proxy));
+
+        // Initialize wrapper via admin
+        vm.prank(admin);
+        wrapper.initialize(address(sovaBTC));
+        sovaBTC.transferOwnership(address(wrapper));
+
+        // Deploy mock tokens
+        wbtc = new MockERC20BTC("Wrapped Bitcoin", "WBTC", 8);
+        lbtc = new MockERC20BTC("Liquid BTC", "LBTC", 18);
+
+        vm.prank(admin);
+        wrapper.addAllowedToken(address(wbtc));
+        vm.prank(admin);
+        wrapper.addAllowedToken(address(lbtc));
+
+        // Fund users and approve
+        wbtc.mint(user1, 1e8);
+        lbtc.mint(user2, 1e18);
+
+        vm.startPrank(user1);
+        wbtc.approve(address(wrapper), type(uint256).max);
+        vm.stopPrank();
+        vm.startPrank(user2);
+        lbtc.approve(address(wrapper), type(uint256).max);
+        vm.stopPrank();
+    }
+
+    function testDepositAndWrap() public {
+        uint256 amount = 1e8; // 1 WBTC
+        vm.expectEmit(true, true, false, true);
+        emit TokenWrapped(user1, address(wbtc), amount, amount);
+        vm.prank(user1);
+        wrapper.deposit(address(wbtc), amount);
+        assertEq(sovaBTC.balanceOf(user1), amount);
+        assertEq(wbtc.balanceOf(address(wrapper)), amount);
+        assertEq(sovaBTC.totalSupply(), amount);
+    }
+
+    function testDepositDifferentDecimals() public {
+        uint256 amount = 1e18; // 1 LBTC
+        uint256 expected = 1e8; // 1 sovaBTC worth
+        vm.prank(user2);
+        wrapper.deposit(address(lbtc), amount);
+        assertEq(sovaBTC.balanceOf(user2), expected);
+        assertEq(lbtc.balanceOf(address(wrapper)), amount);
+        assertEq(sovaBTC.totalSupply(), expected);
+    }
+
+    function testRedeemUnwrap() public {
+        vm.prank(user1);
+        wrapper.deposit(address(wbtc), 1e8);
+        uint256 bal = sovaBTC.balanceOf(user1);
+        vm.prank(user1);
+        wrapper.redeem(address(wbtc), bal);
+        assertEq(wbtc.balanceOf(user1), 1e8);
+        assertEq(sovaBTC.balanceOf(user1), 0);
+        assertEq(sovaBTC.totalSupply(), 0);
+        assertEq(wbtc.balanceOf(address(wrapper)), 0);
+    }
+
+    function testCrossAssetRedemption() public {
+        vm.prank(user1);
+        wrapper.deposit(address(wbtc), 1e8);
+        vm.prank(user2);
+        wrapper.deposit(address(lbtc), 1e18);
+
+        vm.prank(user1);
+        wrapper.redeem(address(lbtc), 1e8);
+        assertEq(lbtc.balanceOf(user1), 1e18);
+        assertEq(sovaBTC.balanceOf(user1), 0);
+        assertEq(lbtc.balanceOf(address(wrapper)), 0);
+
+        vm.prank(user2);
+        wrapper.redeem(address(wbtc), 1e8);
+        assertEq(wbtc.balanceOf(user2), 1e8);
+        assertEq(sovaBTC.balanceOf(user2), 0);
+        assertEq(wbtc.balanceOf(address(wrapper)), 0);
+        assertEq(sovaBTC.totalSupply(), 0);
+    }
+
+    function testNonOwnerCannotAddOrPause() public {
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(user1);
+        wrapper.addAllowedToken(address(0xDEAD));
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(user1);
+        wrapper.pause();
+    }
+
+    function testPauseAndUnpause() public {
+        vm.prank(admin);
+        wrapper.pause();
+
+        vm.expectRevert("Pausable: paused");
+        vm.prank(user1);
+        wrapper.deposit(address(wbtc), 1e8);
+
+        vm.prank(admin);
+        wrapper.unpause();
+        vm.prank(user1);
+        wrapper.deposit(address(wbtc), 1e8);
+    }
+
+    function testRejectUnallowedTokenDeposit() public {
+        MockERC20BTC fakeBTC = new MockERC20BTC("Fake BTC", "FBTC", 8);
+        fakeBTC.mint(user1, 1000);
+        vm.startPrank(user1);
+        fakeBTC.approve(address(wrapper), 1000);
+        vm.expectRevert(TokenWrapper.TokenNotAllowed.selector);
+        wrapper.deposit(address(fakeBTC), 1000);
+        vm.stopPrank();
+    }
+
+    function testMinimumDepositEnforced() public {
+        vm.prank(admin);
+        wrapper.setMinDepositSatoshi(100);
+
+        wbtc.mint(user1, 50);
+        vm.startPrank(user1);
+        wbtc.approve(address(wrapper), 50);
+        vm.expectRevert(TokenWrapper.DepositBelowMinimum.selector);
+        wrapper.deposit(address(wbtc), 50);
+        vm.stopPrank();
+    }
+
+    function testInsufficientReserveReverts() public {
+        vm.prank(user1);
+        wrapper.deposit(address(wbtc), 1e8);
+
+        vm.prank(user1);
+        vm.expectRevert(TokenWrapper.InsufficientReserve.selector);
+        wrapper.redeem(address(lbtc), 1e8);
+    }
+}
+

--- a/test/mocks/MockERC20BTC.sol
+++ b/test/mocks/MockERC20BTC.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {IERC20, IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title MockERC20BTC
+/// @notice Minimal ERC20 used for TokenWrapper tests
+contract MockERC20BTC is IERC20Metadata {
+    string public override name;
+    string public override symbol;
+    uint8 private _decimals;
+    uint256 public override totalSupply;
+
+    mapping(address => uint256) private balances;
+    mapping(address => mapping(address => uint256)) private allowances;
+
+    constructor(string memory _name, string memory _symbol, uint8 decimals_) {
+        name = _name;
+        symbol = _symbol;
+        _decimals = decimals_;
+    }
+
+    function decimals() external view override returns (uint8) {
+        return _decimals;
+    }
+
+    function balanceOf(address account) external view override returns (uint256) {
+        return balances[account];
+    }
+
+    function transfer(address to, uint256 amount) external override returns (bool) {
+        require(balances[msg.sender] >= amount, "Insufficient balance");
+        balances[msg.sender] -= amount;
+        balances[to] += amount;
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function allowance(address owner, address spender) external view override returns (uint256) {
+        return allowances[owner][spender];
+    }
+
+    function approve(address spender, uint256 amount) external override returns (bool) {
+        allowances[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external override returns (bool) {
+        require(balances[from] >= amount, "Insufficient balance");
+        require(allowances[from][msg.sender] >= amount, "Insufficient allowance");
+        allowances[from][msg.sender] -= amount;
+        balances[from] -= amount;
+        balances[to] += amount;
+        emit Transfer(from, to, amount);
+        return true;
+    }
+
+    /// @notice Mint tokens for test usage
+    function mint(address to, uint256 amount) external {
+        balances[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `TokenWrapper.t.sol` covering deposit, redeem, allowlist and pause logic
- introduce `MockERC20BTC.sol` for testing

## Testing
- `forge test -vvv` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ae14dc548332b690a32da49718a6