### PR TITLE
Add TokenWrapper deployment script

### DIFF
--- a/script/DeployTokenWrapper.s.sol
+++ b/script/DeployTokenWrapper.s.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import "forge-std/Script.sol";
+import {TokenWrapper} from "../src/TokenWrapper.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {SovaBTC} from "../src/SovaBTC.sol";
+
+/// @notice Deployment script for the TokenWrapper contract using a UUPS proxy
+contract DeployTokenWrapper is Script {
+    function run() external {
+        uint256 deployerKey = vm.envUint("PRIVATE_KEY");
+        // SovaBTC is predeployed on Sova at the following address
+        address sovaBTCAddress = address(0x2100000000000000000000000000000000000020);
+
+        vm.startBroadcast(deployerKey);
+
+        // Deploy the TokenWrapper implementation and proxy
+        TokenWrapper implementation = new TokenWrapper();
+        ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), "");
+        TokenWrapper wrapper = TokenWrapper(address(proxy));
+
+        // Initialize the proxy instance with the SovaBTC token address
+        wrapper.initialize(sovaBTCAddress);
+
+        // Transfer ownership of SovaBTC to the wrapper so it can mint/burn
+        SovaBTC(sovaBTCAddress).transferOwnership(address(wrapper));
+
+        vm.stopBroadcast();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a `DeployTokenWrapper.s.sol` script for deploying the `TokenWrapper` contract through an ERC1967 proxy
- the script initializes the proxy with the predeployed `SovaBTC` address and transfers ownership of `SovaBTC` to the wrapper

## Testing
- `forge fmt` *(fails: command not found)*
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b071961083328af88615c4461f91