### PR TITLE
Apply dark theme base styles

### DIFF
--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -12,19 +12,19 @@
     --card-foreground: 247 247 248; /* obsidian-50 */
     --popover: 26 26 29; /* obsidian-900 */
     --popover-foreground: 247 247 248; /* obsidian-50 */
-    --primary: 245 158 11; /* bitcoin-500 */
+    --primary: 139 92 246; /* sova-500 */
     --primary-foreground: 26 26 29; /* obsidian-900 */
     --secondary: 68 68 74; /* obsidian-800 */
     --secondary-foreground: 247 247 248; /* obsidian-50 */
     --muted: 68 68 74; /* obsidian-800 */
     --muted-foreground: 184 185 193; /* obsidian-300 */
-    --accent: 6 182 212; /* neon-500 */
+    --accent: 139 92 246; /* sova-500 */
     --accent-foreground: 26 26 29; /* obsidian-900 */
     --destructive: 239 68 68; /* crimson-500 */
     --destructive-foreground: 247 247 248; /* obsidian-50 */
     --border: 95 95 111; /* obsidian-600 */
     --input: 78 79 87; /* obsidian-700 */
-    --ring: 245 158 11; /* bitcoin-500 */
+    --ring: 139 92 246; /* sova-500 */
     --radius: 1rem;
   }
 }

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import { Providers } from "@/components/providers";
 import { Header } from "@/components/layout/header";
+import { cn } from "@/lib/utils";
 
 const inter = Inter({ subsets: ["latin"], variable: '--font-sans' });
 
@@ -25,7 +26,13 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
-      <body className={inter.className} suppressHydrationWarning>
+      <body
+        className={cn(
+          "min-h-screen bg-gray-900 text-gray-100 font-sans",
+          inter.className
+        )}
+        suppressHydrationWarning
+      >
         <Providers>
           <div className="relative flex min-h-screen flex-col">
             <Header />

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -139,6 +139,18 @@ module.exports = {
           900: '#7f1d1d',
           950: '#450a0a',
         },
+        'sova': {
+          50: '#f5f3ff',
+          100: '#ede9fe',
+          200: '#ddd6fe',
+          300: '#c4b5fd',
+          400: '#a78bfa',
+          500: '#8b5cf6', // Brand accent
+          600: '#7c3aed',
+          700: '#6d28d9',
+          800: '#5b21b6',
+          900: '#4c1d95',
+        },
       },
       fontFamily: {
         sans: ["var(--font-sans)", ...fontFamily.sans],


### PR DESCRIPTION
## Summary
- enable dark mode defaults in layout
- use Sova brand color tokens in Tailwind CSS
- add Sova palette and update global CSS variables

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686934f2806c833288a512ae9cbf907a