### PR TITLE
Implement simple navigation bar with wallet connect

### DIFF
--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { Providers } from "@/components/providers";
-import { Header } from "@/components/layout/header";
+import { NavBar } from "@/components/layout/navbar";
 import { cn } from "@/lib/utils";
 
 const inter = Inter({ subsets: ["latin"], variable: '--font-sans' });
@@ -35,7 +35,7 @@ export default function RootLayout({
       >
         <Providers>
           <div className="relative flex min-h-screen flex-col">
-            <Header />
+            <NavBar />
             <main className="flex-1 relative">
               {/* Enhanced Background Effects */}
               <div className="fixed inset-0 -z-10 overflow-hidden">

--- a/ui/src/components/layout/navbar.tsx
+++ b/ui/src/components/layout/navbar.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { ConnectButton } from "@rainbow-me/rainbowkit";
+
+export function NavBar() {
+  return (
+    <nav className="flex items-center justify-between bg-gray-800 px-4 py-3 w-full">
+      <span className="text-xl font-bold text-white">SovaBTC</span>
+      <ConnectButton />
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add `NavBar` component with brand and RainbowKit connect button
- use NavBar in the root layout in place of previous header

## Testing
- `npm run lint` *(fails: several lint errors)*
- `npm run build` *(fails: network access for fonts.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68693be8d1fc83329a8b4cc334dff74e