### PR TITLE
Add Base Sepolia config for wagmi

### DIFF
--- a/ui/src/components/providers.tsx
+++ b/ui/src/components/providers.tsx
@@ -2,9 +2,9 @@
 
 import '@rainbow-me/rainbowkit/styles.css'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { WagmiProvider } from 'wagmi'
+import { WagmiConfig } from 'wagmi'
 import { RainbowKitProvider, darkTheme } from '@rainbow-me/rainbowkit'
-import { wagmiConfig } from '@/config/wagmi'
+import { wagmiConfig, chains } from '@/config/wagmi'
 import { useState, useEffect } from 'react'
 import { Toaster } from 'sonner'
 
@@ -35,9 +35,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <WagmiProvider config={wagmiConfig}>
+    <WagmiConfig config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
-        <RainbowKitProvider 
+        <RainbowKitProvider
+          chains={chains}
           theme={darkTheme({
             accentColor: '#f59e0b',
             accentColorForeground: 'white',
@@ -57,6 +58,6 @@ export function Providers({ children }: { children: React.ReactNode }) {
           />
         </RainbowKitProvider>
       </QueryClientProvider>
-    </WagmiProvider>
+    </WagmiConfig>
   )
 }

--- a/ui/src/config/wagmi.ts
+++ b/ui/src/config/wagmi.ts
@@ -1,14 +1,52 @@
 'use client'
 
-import { getDefaultConfig } from '@rainbow-me/rainbowkit'
-import { baseSepolia } from 'wagmi/chains'
+import { configureChains, createConfig } from 'wagmi'
+import { jsonRpcProvider } from 'wagmi/providers/jsonRpc'
+import { getDefaultWallets } from '@rainbow-me/rainbowkit'
 
-// Get WalletConnect Project ID with fallback
-const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || 'demo-project-id'
+// Custom Base Sepolia chain configuration
+export const baseSepoliaChain = {
+  id: 84531,
+  name: 'Base Sepolia',
+  network: 'base-sepolia',
+  nativeCurrency: { name: 'Ethereum', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://base-sepolia.blockpi.network/v1/rpc/public'],
+    },
+    public: {
+      http: ['https://base-sepolia.blockpi.network/v1/rpc/public'],
+    },
+  },
+  blockExplorers: {
+    default: { name: 'Basescan', url: 'https://base-sepolia.basescan.org' },
+  },
+} as const
 
-export const wagmiConfig = getDefaultConfig({
-  appName: 'SovaBTC - Modern DeFi Protocol',
-  projectId,
-  chains: [baseSepolia],
-  ssr: false, // Disable SSR to avoid indexedDB issues
+// Configure chains with JSON RPC provider
+const { chains, publicClient, webSocketPublicClient } = configureChains(
+  [baseSepoliaChain],
+  [
+    jsonRpcProvider({
+      rpc: () => ({
+        http: baseSepoliaChain.rpcUrls.default.http[0],
+      }),
+    }),
+  ],
+)
+
+// Set up wallet connectors using RainbowKit helper
+const { connectors } = getDefaultWallets({
+  appName: 'SovaBTC dApp',
+  chains,
 })
+
+// Create wagmi configuration
+export const wagmiConfig = createConfig({
+  autoConnect: true,
+  connectors,
+  publicClient,
+  webSocketPublicClient,
+})
+
+export { chains }


### PR DESCRIPTION
## Summary
- configure wagmi to use the Base Sepolia testnet
- expose chains from wagmi config and wire RainbowKit up to them

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, @typescript-eslint/no-unused-vars, etc.)*
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686944961ba88332824d96d3b68b3843